### PR TITLE
Clarify the main profvis loop

### DIFF
--- a/R/profvis.R
+++ b/R/profvis.R
@@ -172,11 +172,11 @@ profvis <- function(expr = NULL,
       filter.callframes = simplify
     ))
 
-    on.exit(Rprof(NULL), add = TRUE)
     if (remove_on_exit) {
       on.exit(unlink(prof_output), add = TRUE)
     }
     repeat {
+      # Work around https://github.com/r-lib/rlang/issues/1749
       eval(substitute(delayedAssign("expr", expr_q, eval.env = env)))
 
       inject(Rprof(prof_output, !!!rprof_args))

--- a/R/profvis.R
+++ b/R/profvis.R
@@ -177,19 +177,19 @@ profvis <- function(expr = NULL,
       on.exit(unlink(prof_output), add = TRUE)
     }
     repeat {
+      eval(substitute(delayedAssign("expr", expr_q, eval.env = env)))
+
       inject(Rprof(prof_output, !!!rprof_args))
       cnd <- with_profvis_handlers(expr)
-      if (!is.null(cnd)) {
-        break
-      }
       Rprof(NULL)
 
       lines <- readLines(prof_output)
+      if (!is.null(cnd)) {
+        break
+      }
       if (prof_matches(zap_header(lines), rerun)) {
         break
       }
-
-      env_bind_lazy(current_env(), expr = !!expr_q, .eval_env = env)
     }
 
     # Must be in the same handler context as `expr` above to get the

--- a/tests/testthat/_snaps/profvis.md
+++ b/tests/testthat/_snaps/profvis.md
@@ -1,0 +1,9 @@
+# can capture profile of code with error
+
+    Code
+      out <- profvis(f(), rerun = "pause")
+    Message
+      profvis: code exited with error:
+      error
+      
+

--- a/tests/testthat/test-profvis.R
+++ b/tests/testthat/test-profvis.R
@@ -35,5 +35,5 @@ test_that("can capture profile of code with error", {
     stop("error")
   }
   expect_snapshot(out <- profvis(f(), rerun = "pause"))
-  expect_equal(profvis_modal_value(out$x$message$prof), "pause f")
+  expect_equal(profile_mode(out), "pause f")
 })

--- a/tests/testthat/test-profvis.R
+++ b/tests/testthat/test-profvis.R
@@ -1,7 +1,7 @@
 test_that("Irrelevant stack is trimmed from profiles (#123)", {
   skip_on_cran()
   skip_on_covr()
-  
+
   f <- function() pause(TEST_PAUSE_TIME)
 
   out <- repro_profvis(f(), simplify = FALSE)
@@ -18,9 +18,18 @@ test_that("defaults to elapsed timing", {
   skip_on_cran()
   skip_on_covr()
   skip_if_not(has_event())
-  
+
   f <- function() Sys.sleep(TEST_PAUSE_TIME)
 
   out <- repro_profvis(f(), rerun = "Sys.sleep")
   expect_equal(profvis_modal_value(out$x$message$prof), "Sys.sleep f")
+})
+
+test_that("can capture profile of code with error", {
+  f <- function() {
+    pause(TEST_PAUSE_TIME)
+    stop("error")
+  }
+  expect_snapshot(out <- profvis(f(), rerun = "pause"))
+  expect_equal(profvis_modal_value(out$x$message$prof), "pause f")
 })


### PR DESCRIPTION
* Ensure that we always terminate `RProf()` even if the expr errors
* Make it a bit more clear how expr works (we regenerate the lazy binding on every iteration)
* Ensure we always set lines, even if the expr errors. (This is what lead to the mystifying lines is not a character vector error)